### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![view on npm](http://img.shields.io/npm/v/operations-orchestration-backup.svg)](https://www.npmjs.org/package/operations-orchestration-backup)
 [![view on npm](http://img.shields.io/npm/l/operations-orchestration-backup.svg)](https://www.npmjs.org/package/operations-orchestration-backup)
 [![npm module downloads](http://img.shields.io/npm/dt/operations-orchestration-backup.svg)](https://www.npmjs.org/package/operations-orchestration-backup)
-[![Known Vulnerabilities](https://snyk.io/test/github/lirantal/operations-orchestration-backup/badge.svg?targetFile=package.json)](https://snyk.io/test/github/lirantal/operations-orchestration-backup?targetFile=package.json)
 [![Build](https://travis-ci.org/lirantal/operations-orchestration-backup.svg?branch=master)](https://travis-ci.org/lirantal/operations-orchestration-backup)
 [![Security Responsible Disclosure](https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg)](https://github.com/nodejs/security-wg/blob/master/processes/responsible_disclosure_template.md)
 


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.